### PR TITLE
Travis-ci build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ script:
 
 addons:
   artifacts:
-    paths : 
-    - samples/**/*.png
-    - NOpenType/bin/Release/*.nupkg
+    paths:
+        - $(find samples/ | tr "\n" ":")
+    target_paths: $TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: csharp
+solution: NRasterizer.sln
+
+matrix:
+  include:
+    - os: linux # Ubuntu 14.04
+      dist: trusty
+      sudo: required
+      dotnet: 1.0.0-preview2-003121
+      mono: latest
+
+branches:
+  only:
+    - master
+
+script:
+  - bash ./build.sh
+  - bash ./build/generate_samples.sh
+
+addons:
+  artifacts:
+    paths : 
+    - samples/**/*.png
+    - NOpenType/bin/Release/*.nupkg

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo Starting build
+
+echo Restoring packages
+
+nuget restore "./NRasterizer.sln"
+
+dotnet restore "./NOpenType/"
+
+echo Running msbuild
+xbuild NRasterizer.sln /p:Configuration=Release
+
+echo Running tests
+nuget install NUnit.Console -Version 3.5.0 -OutputDirectory testrunner
+mono ./testrunner/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./NRasterizer.Tests/bin/Release/NRasterizer.Tests.dll
+
+echo Building nuget packages
+if [ -z "$GitVersion_NuGetVersion" ];
+then
+    dotnet pack -c Release --version-suffix "local-build" ./NOpenType/project.json
+else
+    cd NOpenType
+    echo Setting version number to "%GitVersion_NuGetVersion%"
+    dotnet version "%GitVersion_NuGetVersion%"
+    cd ../ 
+
+    dotnet pack -c Release ./NOpenType/project.json
+fi

--- a/build/generate_samples.sh
+++ b/build/generate_samples.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+PROGRAM=NRasterizer.CLI/bin/Release/NRasterizer.CLI.exe
+
+mono $PROGRAM gdi+ Fonts/CompositeMS.ttf samples/C.png C
+
+# Generate sample with the GDI+ rasterizer
+mono $PROGRAM gdi+ Fonts/segoeui.ttf samples/gdi/cefhijl.png cefhijl
+
+# Generate NRasterizer sample
+mono $PROGRAM nrasterizer Fonts/segoeui.ttf samples/clfx.png clfx


### PR DESCRIPTION
@vidstige managed to figure out how to get this building in travis-ci.

What this doesn't do is produce the final tracked nuget packages with their correct version numbers but it at least runs a build and run the test suite. 

and provides you a way to get those latest renders back on in the readme without github butchering them.